### PR TITLE
fix: Abandoned task re-downloading does not save properly

### DIFF
--- a/lib/src/implementation/ALDownloaderIMP.dart
+++ b/lib/src/implementation/ALDownloaderIMP.dart
@@ -514,7 +514,7 @@ abstract class ALDownloaderIMP {
 
     ALDownloaderInnerTask? task = _getTaskFromUrl(url);
 
-    if (task == null)
+    if (task == null || task.innerStatus == ALDownloaderInnerStatus.deprecated)
       task = _addOrUpdateTaskForUrl(url, '', ALDownloaderInnerStatus.prepared,
           0, null, null, ALDownloaderTaskWaitingPhase.unwaiting);
 


### PR DESCRIPTION
`deprecated` 状态下的任务 `willParameters` 被清空了，如果再次下载无法保存到指定目录。
如果 `task` 为 `deprecated` 状态，用户再次下载更新为 `prepared` 状态。